### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/tlslite/basedb.py
+++ b/tlslite/basedb.py
@@ -51,7 +51,7 @@ class BaseDB(object):
             raise ValueError("Not a recognized database")
 
     def __getitem__(self, username):
-        if self.db == None:
+        if self.db is None:
             raise AssertionError("DB not open")
 
         self.lock.acquire()
@@ -63,7 +63,7 @@ class BaseDB(object):
         return self._getItem(username, valueStr)
 
     def __setitem__(self, username, value):
-        if self.db == None:
+        if self.db is None:
             raise AssertionError("DB not open")
 
         valueStr = self._setItem(username, value)
@@ -77,7 +77,7 @@ class BaseDB(object):
             self.lock.release()
 
     def __delitem__(self, username):
-        if self.db == None:
+        if self.db is None:
             raise AssertionError("DB not open")
 
         self.lock.acquire()
@@ -99,7 +99,7 @@ class BaseDB(object):
         otherwise.
 
         """
-        if self.db == None:
+        if self.db is None:
             raise AssertionError("DB not open")
 
         self.lock.acquire()
@@ -118,7 +118,7 @@ class BaseDB(object):
         @rtype: list
         @return: The usernames in the database.
         """
-        if self.db == None:
+        if self.db is None:
             raise AssertionError("DB not open")
 
         self.lock.acquire()

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -89,7 +89,7 @@ class TLSLocalAlert(TLSAlert):
 
     def __str__(self):
         alertStr = TLSAlert._descriptionStr.get(self.description)
-        if alertStr == None:
+        if alertStr is None:
             alertStr = str(self.description)
         if self.message:
             return alertStr + ": " + self.message
@@ -113,7 +113,7 @@ class TLSRemoteAlert(TLSAlert):
 
     def __str__(self):
         alertStr = TLSAlert._descriptionStr.get(self.description)
-        if alertStr == None:
+        if alertStr is None:
             alertStr = str(self.description)
         return alertStr
 

--- a/tlslite/integration/asyncstatemachine.py
+++ b/tlslite/integration/asyncstatemachine.py
@@ -53,7 +53,7 @@ class AsyncStateMachine:
         if self.writer:
             activeOps += 1
 
-        if self.result == None:
+        if self.result is None:
             if activeOps != 0:
                 raise AssertionError()
         elif self.result in (0,1):
@@ -74,7 +74,7 @@ class AsyncStateMachine:
         @rtype: bool or None
         @return: If the state machine wants to read.
         """
-        if self.result != None:
+        if self.result is not None:
             return self.result == 0
         return None
 
@@ -88,7 +88,7 @@ class AsyncStateMachine:
         @rtype: bool or None
         @return: If the state machine wants to write.
         """
-        if self.result != None:
+        if self.result is not None:
             return self.result == 1
         return None
 

--- a/tlslite/integration/tlsasyncdispatchermixin.py
+++ b/tlslite/integration/tlsasyncdispatchermixin.py
@@ -98,13 +98,13 @@ class TLSAsyncDispatcherMixIn(AsyncStateMachine):
 
     def readable(self):
         result = self.wantsReadEvent()
-        if result != None:
+        if result is not None:
             return result
         return self.siblingClass.readable(self)
 
     def writable(self):
         result = self.wantsWriteEvent()
-        if result != None:
+        if result is not None:
             return result
         return self.siblingClass.writable(self)
 
@@ -128,7 +128,7 @@ class TLSAsyncDispatcherMixIn(AsyncStateMachine):
         self.siblingClass.handle_write(self)
 
     def recv(self, bufferSize=16384):
-        if bufferSize < 16384 or self.readBuffer == None:
+        if bufferSize < 16384 or self.readBuffer is None:
             raise AssertionError()
         returnValue = self.readBuffer
         self.readBuffer = None

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -489,7 +489,7 @@ class TLSConnection(TLSRecordLayer):
         self.session = Session()
         self.session.create(masterSecret, serverHello.session_id, cipherSuite,
             srpUsername, clientCertChain, serverCertChain,
-            tackExt, serverHello.tackExt!=None, serverName)
+            tackExt, serverHello.tackExtis notNone, serverName)
         self._handshakeDone(resumed=False)
 
 
@@ -1126,7 +1126,7 @@ class TLSConnection(TLSRecordLayer):
                                             verifierDB, sessionCache,
                                             anon):
             if result in (0,1): yield result
-            elif result == None:
+            elif result is None:
                 self._handshakeDone(resumed=True)                
                 return # Handshake was resumed, we're done 
             else: break
@@ -1211,7 +1211,7 @@ class TLSConnection(TLSRecordLayer):
             serverName = clientHello.server_name.decode("utf-8")
         self.session.create(masterSecret, serverHello.session_id, cipherSuite,
             srpUsername, clientCertChain, serverCertChain,
-            tackExt, serverHello.tackExt!=None, serverName)
+            tackExt, serverHello.tackExtis notNone, serverName)
             
         #Add the session object to the session cache
         if sessionCache and sessionID:

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -218,7 +218,7 @@ class TLSRecordLayer(object):
                     else:
                         self._shutdown(True)
 
-            if max == None:
+            if max is None:
                 max = len(self._readBuffer)
 
             returnBytes = self._readBuffer[:max]

--- a/tlslite/utils/cipherfactory.py
+++ b/tlslite/utils/cipherfactory.py
@@ -40,7 +40,7 @@ def createAES(key, IV, implList=None):
     @rtype: L{tlslite.utils.AES}
     @return: An AES object.
     """
-    if implList == None:
+    if implList is None:
         implList = ["openssl", "pycrypto", "python"]
 
     for impl in implList:
@@ -64,7 +64,7 @@ def createRC4(key, IV, implList=None):
     @rtype: L{tlslite.utils.RC4}
     @return: An RC4 object.
     """
-    if implList == None:
+    if implList is None:
         implList = ["openssl", "pycrypto", "python"]
 
     if len(IV) != 0:
@@ -91,7 +91,7 @@ def createTripleDES(key, IV, implList=None):
     @rtype: L{tlslite.utils.TripleDES}
     @return: A 3DES object.
     """
-    if implList == None:
+    if implList is None:
         implList = ["openssl", "pycrypto"]
 
     for impl in implList:

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -109,7 +109,7 @@ def numberToByteArray(n, howManyBytes=None):
     not be larger.  The returned bytearray will contain a big-endian
     encoding of the input integer (n).
     """    
-    if howManyBytes == None:
+    if howManyBytes is None:
         howManyBytes = numBytes(n)
     b = bytearray(howManyBytes)
     for count in range(howManyBytes-1, -1, -1):

--- a/tlslite/utils/openssl_rsakey.py
+++ b/tlslite/utils/openssl_rsakey.py
@@ -104,7 +104,7 @@ if m2cryptoLoaded:
                 raise SyntaxError()
             s = s[start:]            
             if s.startswith("-----BEGIN "):
-                if passwordCallback==None:
+                if passwordCallbackisNone:
                     callback = password_callback
                 else:
                     def f(v, prompt1=None, prompt2=None):
@@ -118,7 +118,7 @@ if m2cryptoLoaded:
                     if s.startswith("-----BEGIN RSA PRIVATE KEY-----"):
                         def f():pass
                         key.rsa = m2.rsa_read_key(bio, callback)
-                        if key.rsa == None:
+                        if key.rsa is None:
                             raise SyntaxError()
                         key._hasPrivateKey = True
                     # parse a standard PKCS#8 PEM file
@@ -132,15 +132,15 @@ if m2cryptoLoaded:
                         # if the file actually has a RSA key in it)
                         # tlslite doesn't support DSA or EC so it's useless
                         # to handle them in a different way
-                        if key.rsa == None:
+                        if key.rsa is None:
                             raise SyntaxError()
                         key.rsa = m2.pkey_get1_rsa(key.rsa)
-                        if key.rsa == None:
+                        if key.rsa is None:
                             raise SyntaxError()
                         key._hasPrivateKey = True
                     elif s.startswith("-----BEGIN PUBLIC KEY-----"):
                         key.rsa = m2.rsa_read_pub_key(bio)
-                        if key.rsa == None:
+                        if key.rsa is None:
                             raise SyntaxError()
                         key._hasPrivateKey = False
                     else:

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -891,7 +891,7 @@ class TestTACKExtension(unittest.TestCase):
         b = TACKExtension.TACK()
 
         self.assertTrue(a == b)
-        self.assertFalse(a == None)
+        self.assertFalse(a is None)
         self.assertFalse(a == "test")
 
     def test_tack___eq___with_different_tacks(self):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:tlslite?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:tlslite?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
