### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -38,12 +38,12 @@ except ImportError:
 
 def printUsage(s=None):
     if s:
-        print("ERROR: %s" % s)
+        print("ERROR: {0!s}".format(s))
 
     print("")
-    print("Version: %s" % __version__)
+    print("Version: {0!s}".format(__version__))
     print("")
-    print("RNG: %s" % prngName)
+    print("RNG: {0!s}".format(prngName))
     print("")
     print("Modules:")
     if tackpyLoaded:
@@ -78,7 +78,7 @@ def printUsage(s=None):
 
 def printError(s):
     """Print error message and exit"""
-    sys.stderr.write("ERROR: %s\n" % s)
+    sys.stderr.write("ERROR: {0!s}\n".format(s))
     sys.exit(-1)
 
 
@@ -160,28 +160,28 @@ def handleArgs(argv, argString, flagsList=[]):
 
 
 def printGoodConnection(connection, seconds):
-    print("  Handshake time: %.3f seconds" % seconds)
-    print("  Version: %s" % connection.getVersionName())
-    print("  Cipher: %s %s" % (connection.getCipherName(), 
+    print("  Handshake time: {0:.3f} seconds".format(seconds))
+    print("  Version: {0!s}".format(connection.getVersionName()))
+    print("  Cipher: {0!s} {1!s}".format(connection.getCipherName(), 
         connection.getCipherImplementation()))
     if connection.session.srpUsername:
-        print("  Client SRP username: %s" % connection.session.srpUsername)
+        print("  Client SRP username: {0!s}".format(connection.session.srpUsername))
     if connection.session.clientCertChain:
-        print("  Client X.509 SHA1 fingerprint: %s" % 
-            connection.session.clientCertChain.getFingerprint())
+        print("  Client X.509 SHA1 fingerprint: {0!s}".format( 
+            connection.session.clientCertChain.getFingerprint()))
     if connection.session.serverCertChain:
-        print("  Server X.509 SHA1 fingerprint: %s" % 
-            connection.session.serverCertChain.getFingerprint())
+        print("  Server X.509 SHA1 fingerprint: {0!s}".format( 
+            connection.session.serverCertChain.getFingerprint()))
     if connection.session.serverName:
-        print("  SNI: %s" % connection.session.serverName)
+        print("  SNI: {0!s}".format(connection.session.serverName))
     if connection.session.tackExt:   
         if connection.session.tackInHelloExt:
             emptyStr = "\n  (via TLS Extension)"
         else:
             emptyStr = "\n  (via TACK Certificate)" 
-        print("  TACK: %s" % emptyStr)
+        print("  TACK: {0!s}".format(emptyStr))
         print(str(connection.session.tackExt))
-    print("  Next-Protocol Negotiated: %s" % connection.next_proto) 
+    print("  Next-Protocol Negotiated: {0!s}".format(connection.next_proto)) 
     
 
 def clientCmd(argv):
@@ -250,11 +250,10 @@ def serverCmd(argv):
     if tacks and not certChain:
         raise SyntaxError("Must specify CERT with Tacks")
     
-    print("I am an HTTPS test server, I will listen on %s:%d" % 
-            (address[0], address[1]))    
+    print("I am an HTTPS test server, I will listen on {0!s}:{1:d}".format(address[0], address[1]))    
     if directory:
         os.chdir(directory)
-    print("Serving files from %s" % os.getcwd())
+    print("Serving files from {0!s}".format(os.getcwd()))
     
     if certChain and privateKey:
         print("Using certificate and private key...")
@@ -332,5 +331,5 @@ if __name__ == '__main__':
     elif sys.argv[1] == "server"[:len(sys.argv[1])]:
         serverCmd(sys.argv[2:])
     else:
-        printUsage("Unknown command: %s" % sys.argv[1])
+        printUsage("Unknown command: {0!s}".format(sys.argv[1]))
 

--- a/scripts/tlsdb.py
+++ b/scripts/tlsdb.py
@@ -21,9 +21,9 @@ from tlslite import __version__
 
 if len(sys.argv) == 1 or (len(sys.argv)==2 and sys.argv[1].lower().endswith("help")):
     print("")
-    print("Version: %s" % __version__)
+    print("Version: {0!s}".format(__version__))
     print("")
-    print("RNG: %s" % prngName)
+    print("RNG: {0!s}".format(prngName))
     print("")
     print("Modules:")
     if m2cryptoLoaded:
@@ -78,7 +78,7 @@ try:
         if command == "valid":
             print("")
         else:
-            print("Bad command: '%s'" % command)
+            print("Bad command: '{0!s}'".format(command))
 
     elif cmd == "createsrp":
         dbName = args.get(2)
@@ -145,6 +145,6 @@ try:
             N, g, s, v = db[username]
             print(numBits(N), username)
     else:
-        print("Bad command: '%s'" % cmd)
+        print("Bad command: '{0!s}'".format(cmd))
 except:
     raise

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -52,14 +52,14 @@ def printUsage(s=None):
     else:
         crypto = "Python crypto"        
     if s:
-        print("ERROR: %s" % s)
-    print("""\ntls.py version %s (using %s)  
+        print("ERROR: {0!s}".format(s))
+    print("""\ntls.py version {0!s} (using {1!s})  
 
 Commands:
   server HOST:PORT DIRECTORY
 
   client HOST:PORT DIRECTORY
-""" % (__version__, crypto))
+""".format(__version__, crypto))
     sys.exit(-1)
     
 
@@ -180,9 +180,9 @@ def clientTestCmd(argv):
         connection.fault = fault
         try:
             connection.handshakeClientSRP("test", "password")
-            print("  Good Fault %s" % (Fault.faultNames[fault]))
+            print("  Good Fault {0!s}".format((Fault.faultNames[fault])))
         except TLSFaultError as e:
-            print("  BAD FAULT %s: %s" % (Fault.faultNames[fault], str(e)))
+            print("  BAD FAULT {0!s}: {1!s}".format(Fault.faultNames[fault], str(e)))
             badFault = True
 
     print("Test 6 - good SRP: with X.509 certificate, TLSv1.0")
@@ -203,9 +203,9 @@ def clientTestCmd(argv):
         connection.fault = fault
         try:
             connection.handshakeClientSRP("test", "password")
-            print("  Good Fault %s" % (Fault.faultNames[fault]))
+            print("  Good Fault {0!s}".format((Fault.faultNames[fault])))
         except TLSFaultError as e:
-            print("  BAD FAULT %s: %s" % (Fault.faultNames[fault], str(e)))
+            print("  BAD FAULT {0!s}: {1!s}".format(Fault.faultNames[fault], str(e)))
             badFault = True
 
     print("Test 11 - X.509 faults")
@@ -215,9 +215,9 @@ def clientTestCmd(argv):
         connection.fault = fault
         try:
             connection.handshakeClientCert()
-            print("  Good Fault %s" % (Fault.faultNames[fault]))
+            print("  Good Fault {0!s}".format((Fault.faultNames[fault])))
         except TLSFaultError as e:
-            print("  BAD FAULT %s: %s" % (Fault.faultNames[fault], str(e)))
+            print("  BAD FAULT {0!s}: {1!s}".format(Fault.faultNames[fault], str(e)))
             badFault = True
 
     print("Test 14 - good mutual X509")
@@ -251,9 +251,9 @@ def clientTestCmd(argv):
         connection.fault = fault
         try:
             connection.handshakeClientCert(x509Chain, x509Key)
-            print("  Good Fault %s" % (Fault.faultNames[fault]))
+            print("  Good Fault {0!s}".format((Fault.faultNames[fault])))
         except TLSFaultError as e:
-            print("  BAD FAULT %s: %s" % (Fault.faultNames[fault], str(e)))
+            print("  BAD FAULT {0!s}: {1!s}".format(Fault.faultNames[fault], str(e)))
             badFault = True
 
     print("Test 18 - good SRP, prepare to resume... (plus SNI)")
@@ -338,7 +338,7 @@ def clientTestCmd(argv):
             settings.maxVersion = (3,1)            
             connection.handshakeClientCert(settings=settings)
             testConnClient(connection)
-            print("%s %s" % (connection.getCipherName(), connection.getCipherImplementation()))
+            print("{0!s} {1!s}".format(connection.getCipherName(), connection.getCipherImplementation()))
             connection.close()
 
     print("Test 23 - throughput test")
@@ -355,14 +355,14 @@ def clientTestCmd(argv):
             settings.cipherNames = [cipher]
             settings.cipherImplementations = [implementation, "python"]
             connection.handshakeClientCert(settings=settings)
-            print("%s %s:" % (connection.getCipherName(), connection.getCipherImplementation()), end=' ')
+            print("{0!s} {1!s}:".format(connection.getCipherName(), connection.getCipherImplementation()), end=' ')
 
             startTime = time.clock()
             connection.write(b"hello"*10000)
             h = connection.read(min=50000, max=50000)
             stopTime = time.clock()
             if stopTime-startTime:
-                print("100K exchanged at rate of %d bytes/sec" % int(100000/(stopTime-startTime)))
+                print("100K exchanged at rate of {0:d} bytes/sec".format(int(100000/(stopTime-startTime))))
             else:
                 print("100K exchanged very fast")
 
@@ -456,9 +456,9 @@ def clientTestCmd(argv):
         # python 3.4.2 doesn't have it though
         context = ssl.create_default_context(\
                 cafile=os.path.join(dir, "serverX509Cert.pem"))
-        server = xmlrpclib.Server('https://%s:%s' % address, context=context)
+        server = xmlrpclib.Server('https://{0!s}:{1!s}'.format(*address), context=context)
     except (TypeError, AttributeError):
-        server = xmlrpclib.Server('https://%s:%s' % address)
+        server = xmlrpclib.Server('https://{0!s}:{1!s}'.format(*address))
 
     synchro.recv(1)
     assert server.add(1,2) == 3
@@ -467,14 +467,14 @@ def clientTestCmd(argv):
 
     print('Test 27 - good tlslite XMLRPC client')
     transport = XMLRPCTransport(ignoreAbruptClose=True)
-    server = xmlrpclib.Server('https://%s:%s' % address, transport)
+    server = xmlrpclib.Server('https://{0!s}:{1!s}'.format(*address), transport)
     synchro.recv(1)
     assert server.add(1,2) == 3
     synchro.recv(1)
     assert server.pow(2,4) == 16
 
     print('Test 28 - good XMLRPC ignored protocol')
-    server = xmlrpclib.Server('http://%s:%s' % address, transport)
+    server = xmlrpclib.Server('http://{0!s}:{1!s}'.format(*address), transport)
     synchro.recv(1)
     assert server.add(1,2) == 3
     synchro.recv(1)
@@ -927,4 +927,4 @@ if __name__ == '__main__':
     elif sys.argv[1] == "server"[:len(sys.argv[1])]:
         serverTestCmd(sys.argv[2:])
     else:
-        printUsage("Unknown command: %s" % sys.argv[1])
+        printUsage("Unknown command: {0!s}".format(sys.argv[1]))

--- a/tlslite/basedb.py
+++ b/tlslite/basedb.py
@@ -46,7 +46,7 @@ class BaseDB(object):
         self.db = anydbm.open(self.filename, "w") #raises anydbm.error
         try:
             if self.db["--Reserved--type"] != self.type:
-                raise ValueError("Not a %s database" % self.type)
+                raise ValueError("Not a {0!s} database".format(self.type))
         except KeyError:
             raise ValueError("Not a recognized database")
 

--- a/tlslite/checker.py
+++ b/tlslite/checker.py
@@ -69,8 +69,7 @@ class Checker(object):
                     if self.x509Fingerprint:
                         if chain.getFingerprint() != self.x509Fingerprint:
                             raise TLSFingerprintError(\
-                                "X.509 fingerprint mismatch: %s, %s" % \
-                                (chain.getFingerprint(), self.x509Fingerprint))
+                                "X.509 fingerprint mismatch: {0!s}, {1!s}".format(chain.getFingerprint(), self.x509Fingerprint))
                 elif chain:
                     raise TLSAuthenticationTypeError()
                 else:

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -159,13 +159,13 @@ class HandshakeSettings(object):
             raise ValueError("maxKeySize smaller than minKeySize")
         for s in other.cipherNames:
             if s not in CIPHER_NAMES:
-                raise ValueError("Unknown cipher name: '%s'" % s)
+                raise ValueError("Unknown cipher name: '{0!s}'".format(s))
         for s in other.cipherImplementations:
             if s not in CIPHER_IMPLEMENTATIONS:
-                raise ValueError("Unknown cipher implementation: '%s'" % s)
+                raise ValueError("Unknown cipher implementation: '{0!s}'".format(s))
         for s in other.certificateTypes:
             if s not in CERTIFICATE_TYPES:
-                raise ValueError("Unknown certificate type: '%s'" % s)
+                raise ValueError("Unknown certificate type: '{0!s}'".format(s))
 
         if other.minVersion > other.maxVersion:
             raise ValueError("Versions set incorrectly")

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -564,12 +564,12 @@ class TLSConnection(TLSRecordLayer):
         if serverHello.server_version < settings.minVersion:
             for result in self._sendError(\
                 AlertDescription.protocol_version,
-                "Too old version: %s" % str(serverHello.server_version)):
+                "Too old version: {0!s}".format(str(serverHello.server_version))):
                 yield result
         if serverHello.server_version > settings.maxVersion:
             for result in self._sendError(\
                 AlertDescription.protocol_version,
-                "Too new version: %s" % str(serverHello.server_version)):
+                "Too new version: {0!s}".format(str(serverHello.server_version))):
                 yield result
         if serverHello.cipher_suite not in clientHello.cipher_suites:
             for result in self._sendError(\
@@ -693,12 +693,12 @@ class TLSConnection(TLSRecordLayer):
         if numBits(N) < settings.minKeySize:
             for result in self._sendError(\
                     AlertDescription.insufficient_security,
-                    "N value is too small: %d" % numBits(N)):
+                    "N value is too small: {0:d}".format(numBits(N))):
                 yield result
         if numBits(N) > settings.maxKeySize:
             for result in self._sendError(\
                     AlertDescription.insufficient_security,
-                    "N value is too large: %d" % numBits(N)):
+                    "N value is too large: {0:d}".format(numBits(N))):
                 yield result
         if B % N == 0:
             for result in self._sendError(\
@@ -940,11 +940,11 @@ class TLSConnection(TLSRecordLayer):
         publicKey = certChain.getEndEntityPublicKey()
         if len(publicKey) < settings.minKeySize:
             for result in self._sendError(AlertDescription.handshake_failure,
-                    "Other party's public key too small: %d" % len(publicKey)):
+                    "Other party's public key too small: {0:d}".format(len(publicKey))):
                 yield result
         if len(publicKey) > settings.maxKeySize:
             for result in self._sendError(AlertDescription.handshake_failure,
-                    "Other party's public key too large: %d" % len(publicKey)):
+                    "Other party's public key too large: {0:d}".format(len(publicKey))):
                 yield result
         
         # If there's no TLS Extension, look for a TACK cert
@@ -1253,7 +1253,7 @@ class TLSConnection(TLSRecordLayer):
             self.version = settings.minVersion
             for result in self._sendError(\
                   AlertDescription.protocol_version,
-                  "Too old version: %s" % str(clientHello.client_version)):
+                  "Too old version: {0!s}".format(str(clientHello.client_version))):
                 yield result
 
         #If client's version is too high, propose my highest version
@@ -1546,13 +1546,13 @@ class TLSConnection(TLSRecordLayer):
             if len(publicKey) < settings.minKeySize:
                 for result in self._sendError(\
                         AlertDescription.handshake_failure,
-                        "Client's public key too small: %d" % len(publicKey)):
+                        "Client's public key too small: {0:d}".format(len(publicKey))):
                     yield result
 
             if len(publicKey) > settings.maxKeySize:
                 for result in self._sendError(\
                         AlertDescription.handshake_failure,
-                        "Client's public key too large: %d" % len(publicKey)):
+                        "Client's public key too large: {0:d}".format(len(publicKey))):
                     yield result
 
             if not publicKey.verify(certificateVerify.signature, verifyBytes):

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -742,7 +742,7 @@ class TLSRecordLayer(object):
                     #alert nor renegotiation
                     for result in self._sendError(\
                             AlertDescription.unexpected_message,
-                            "received type=%d" % recordHeader.type):
+                            "received type={0:d}".format(recordHeader.type)):
                         yield result
 
                 break
@@ -777,7 +777,7 @@ class TLSRecordLayer(object):
                     if subType not in secondaryType:
                         for result in self._sendError(\
                                 AlertDescription.unexpected_message,
-                                "Expecting %s, got %s" % (str(secondaryType), subType)):
+                                "Expecting {0!s}, got {1!s}".format(str(secondaryType), subType)):
                             yield result
 
                 #Update handshake hashes

--- a/tlslite/utils/compat.py
+++ b/tlslite/utils/compat.py
@@ -29,14 +29,14 @@ if sys.version_info >= (3,0):
         try:
             b = bytearray(binascii.a2b_hex(bytearray(s, "ascii")))
         except Exception as e:
-            raise SyntaxError("base16 error: %s" % e) 
+            raise SyntaxError("base16 error: {0!s}".format(e)) 
         return b  
 
     def a2b_base64(s):
         try:
             b = bytearray(binascii.a2b_base64(bytearray(s, "ascii")))
         except Exception as e:
-            raise SyntaxError("base64 error: %s" % e)
+            raise SyntaxError("base64 error: {0!s}".format(e))
         return b
 
     def b2a_hex(b):
@@ -67,14 +67,14 @@ else:
         try:
             b = bytearray(binascii.a2b_hex(s))
         except Exception as e:
-            raise SyntaxError("base16 error: %s" % e)
+            raise SyntaxError("base16 error: {0!s}".format(e))
         return b
 
     def a2b_base64(s):
         try:
             b = bytearray(binascii.a2b_base64(s))
         except Exception as e:
-            raise SyntaxError("base64 error: %s" % e)
+            raise SyntaxError("base64 error: {0!s}".format(e))
         return b
         
     def b2a_hex(b):

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -146,7 +146,7 @@ def numberToMPI(n):
 def numBits(n):
     if n==0:
         return 0
-    s = "%x" % n
+    s = "{0:x}".format(n)
     return ((len(s)-1)*4) + \
     {'0':0, '1':1, '2':2, '3':2,
      '4':3, '5':3, '6':3, '7':3,

--- a/tlslite/utils/datefuncs.py
+++ b/tlslite/utils/datefuncs.py
@@ -54,8 +54,7 @@ else:
         return c
 
     def printDateClass(d):
-        return "%04d-%02d-%02dT%02d:%02d:%02dZ" % \
-        (d.get(d.YEAR), d.get(d.MONTH)+1, d.get(d.DATE), \
+        return "{0:04d}-{1:02d}-{2:02d}T{3:02d}:{4:02d}:{5:02d}Z".format(d.get(d.YEAR), d.get(d.MONTH)+1, d.get(d.DATE), \
         d.get(d.HOUR_OF_DAY), d.get(d.MINUTE), d.get(d.SECOND))
 
     def getNow():

--- a/tlslite/utils/pem.py
+++ b/tlslite/utils/pem.py
@@ -22,15 +22,15 @@ def dePem(s, name):
     The first such PEM block in the input will be found, and its
     payload will be base64 decoded and returned.
     """
-    prefix  = "-----BEGIN %s-----" % name
-    postfix = "-----END %s-----" % name    
+    prefix  = "-----BEGIN {0!s}-----".format(name)
+    postfix = "-----END {0!s}-----".format(name)    
     start = s.find(prefix)
     if start == -1:
         raise SyntaxError("Missing PEM prefix")
     end = s.find(postfix, start+len(prefix))
     if end == -1:
         raise SyntaxError("Missing PEM postfix")
-    s = s[start+len("-----BEGIN %s-----" % name) : end]
+    s = s[start+len("-----BEGIN {0!s}-----".format(name)) : end]
     retBytes = a2b_base64(s) # May raise SyntaxError
     return retBytes
     
@@ -59,8 +59,8 @@ def dePemList(s, name):
     of bytearrays, which may have zero elements if not PEM blocks are found.
     """
     bList = []
-    prefix  = "-----BEGIN %s-----" % name
-    postfix = "-----END %s-----" % name
+    prefix  = "-----BEGIN {0!s}-----".format(name)
+    postfix = "-----END {0!s}-----".format(name)
     while 1:
         start = s.find(prefix)
         if start == -1:
@@ -90,10 +90,10 @@ def pem(b, name):
     while s1:
         s2 += s1[:64] + "\n"
         s1 = s1[64:]
-    s = ("-----BEGIN %s-----\n" % name) + s2 + \
-        ("-----END %s-----\n" % name)     
+    s = ("-----BEGIN {0!s}-----\n".format(name)) + s2 + \
+        ("-----END {0!s}-----\n".format(name))     
     return s
 
 def pemSniff(inStr, name):
-    searchStr = "-----BEGIN %s-----" % name
+    searchStr = "-----BEGIN {0!s}-----".format(name)
     return searchStr in inStr


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:tlslite?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:tlslite?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
